### PR TITLE
visit_categoriesとdestinationsの追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,8 @@ gem 'omniauth-google-oauth2'
 gem 'omniauth-line'
 gem 'omniauth-rails_csrf_protection'
 
+gem 'geocoder'
+
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", "~> 5.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.0)
       railties (>= 6.0.0)
+    csv (3.3.0)
     date (3.3.4)
     debug (1.9.2)
       irb (~> 1.10)
@@ -104,6 +105,9 @@ GEM
     faraday-net_http (3.1.0)
       net-http
     fly (0.0.1)
+    geocoder (1.8.3)
+      base64 (>= 0.1.0)
+      csv (>= 3.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
@@ -291,6 +295,7 @@ DEPENDENCIES
   dockerfile-rails (>= 1.6)
   dotenv-rails
   fly
+  geocoder
   jbuilder
   jsbundling-rails
   omniauth

--- a/app/controllers/search_results_controller.rb
+++ b/app/controllers/search_results_controller.rb
@@ -1,0 +1,2 @@
+class SearchResultsController < ApplicationController
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,7 +7,7 @@ class SessionsController < ApplicationController
   end
 
   def destroy
-    session[:user_id] = nil
+    reset_session
     flash[:info] = 'ログアウトしました'
     redirect_to root_path, status: :see_other
   end

--- a/app/helpers/search_results_helper.rb
+++ b/app/helpers/search_results_helper.rb
@@ -1,0 +1,2 @@
+module SearchResultsHelper
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,14 +1,11 @@
-// Entry point for the build script in your package.json
-
+// app/javascript/application.js
 function initMap() {
-  // 地図の初期設定
   var mapOptions = {
     zoom: 10,
     center: { lat: 35.681236, lng: 139.767125 }  // デフォルトの位置
   };
   var map = new google.maps.Map(document.getElementById('map'), mapOptions);
 
-  // 現在地を取得
   if (navigator.geolocation) {
     navigator.geolocation.getCurrentPosition(function(position) {
       var pos = {
@@ -20,7 +17,6 @@ function initMap() {
       handleLocationError(true, map.getCenter());
     });
   } else {
-    // Geolocationがサポートされていない場合
     handleLocationError(false, map.getCenter());
   }
 }
@@ -29,6 +25,5 @@ function handleLocationError(browserHasGeolocation, pos) {
   alert(browserHasGeolocation ? "エラー: Geolocationサービスに失敗しました。" : "エラー: お使いのブラウザはGeolocationをサポートしていません。");
 }
 
-document.addEventListener('DOMContentLoaded', function() {
-  initMap();
-});
+// initMap関数をグローバルスコープに設定
+window.initMap = initMap;

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,1 +1,34 @@
 // Entry point for the build script in your package.json
+
+function initMap() {
+  // 地図の初期設定
+  var mapOptions = {
+    zoom: 10,
+    center: { lat: 35.681236, lng: 139.767125 }  // デフォルトの位置
+  };
+  var map = new google.maps.Map(document.getElementById('map'), mapOptions);
+
+  // 現在地を取得
+  if (navigator.geolocation) {
+    navigator.geolocation.getCurrentPosition(function(position) {
+      var pos = {
+        lat: position.coords.latitude,
+        lng: position.coords.longitude
+      };
+      map.setCenter(pos); // 現在地に中心を設定
+    }, function() {
+      handleLocationError(true, map.getCenter());
+    });
+  } else {
+    // Geolocationがサポートされていない場合
+    handleLocationError(false, map.getCenter());
+  }
+}
+
+function handleLocationError(browserHasGeolocation, pos) {
+  alert(browserHasGeolocation ? "エラー: Geolocationサービスに失敗しました。" : "エラー: お使いのブラウザはGeolocationをサポートしていません。");
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+  initMap();
+});

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -1,5 +1,5 @@
 class Condition < ApplicationRecord
   belongs_to :user
 
-  enum type: { distance: 0, time: 1 }
+  enum condition_type: { distance: 0, time: 1 }
 end

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -1,0 +1,2 @@
+class Destination < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  has_many :conditions
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
       user.provider = auth.provider

--- a/app/models/visit_category.rb
+++ b/app/models/visit_category.rb
@@ -1,3 +1,4 @@
 class VisitCategory < ApplicationRecord
+  has_many :destinations
   enum name: { scenic_spot: 0, tourist_attraction: 1, roadside_station: 2 }
 end

--- a/app/models/visit_category.rb
+++ b/app/models/visit_category.rb
@@ -1,0 +1,3 @@
+class VisitCategory < ApplicationRecord
+  enum name: { scenic_spot: 0, tourist_attraction: 1, roadside_station: 2 }
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,8 +7,8 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
-    <%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_API_KEY']}&libraries=places" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+    <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAPS_API_KEY'] %>&callback=initMap" async defer></script>
   </head>
 
   <body>

--- a/app/views/search_results/index.html.erb
+++ b/app/views/search_results/index.html.erb
@@ -1,2 +1,1 @@
-<div id="map" style="height: 400px;"></div>
-<script async defer src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAPS_API_KEY'] %>&callback=initMap"></script>
+<div id="map" style="height: 400px; width: 100%;"></div>

--- a/app/views/search_results/index.html.erb
+++ b/app/views/search_results/index.html.erb
@@ -1,0 +1,2 @@
+<div id="map" style="height: 400px;"></div>
+<script async defer src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAPS_API_KEY'] %>&callback=initMap"></script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,12 @@
 Rails.application.routes.draw do
-  get 'staticpages/top'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   root 'staticpages#top'
 
   get 'auth/:provider/callback', to: 'sessions#create'
   get 'auth/failure', to: redirect('/')
   get 'signout', to: 'sessions#destroy', as: 'signout'
+
+  get 'search_results', to: 'search_results#index'
 
   resource :users, only: %i[show edit update]
   # Defines the root path route ("/")

--- a/db/migrate/20240529143701_rename_type_column_in_conditions.rb
+++ b/db/migrate/20240529143701_rename_type_column_in_conditions.rb
@@ -1,0 +1,5 @@
+class RenameTypeColumnInConditions < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :conditions, :type, :condition_type
+  end
+end

--- a/db/migrate/20240530060658_create_visit_categories.rb
+++ b/db/migrate/20240530060658_create_visit_categories.rb
@@ -1,0 +1,9 @@
+class CreateVisitCategories < ActiveRecord::Migration[7.0]
+  def change
+    create_table :visit_categories do |t|
+      t.integer :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240530062714_create_destinations.rb
+++ b/db/migrate/20240530062714_create_destinations.rb
@@ -1,0 +1,16 @@
+class CreateDestinations < ActiveRecord::Migration[7.0]
+  def change
+    create_table :destinations do |t|
+      t.references :visit_category, foreign_key: true
+      t.string :name, null: false
+      t.string :address, null: false
+      t.float :latitude, null: false
+      t.float :longitude, null: false
+      t.float :rating
+      t.string :image
+      t.string :business_hours
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_29_143701) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_30_060658) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -32,6 +32,12 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_29_143701) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
+  end
+
+  create_table "visit_categories", force: :cascade do |t|
+    t.integer "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   add_foreign_key "conditions", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_30_060658) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_30_062714) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,20 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_30_060658) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_conditions_on_user_id"
+  end
+
+  create_table "destinations", force: :cascade do |t|
+    t.bigint "visit_category_id"
+    t.string "name", null: false
+    t.string "address", null: false
+    t.float "latitude", null: false
+    t.float "longitude", null: false
+    t.float "rating"
+    t.string "image"
+    t.string "business_hours"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["visit_category_id"], name: "index_destinations_on_visit_category_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -41,4 +55,5 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_30_060658) do
   end
 
   add_foreign_key "conditions", "users"
+  add_foreign_key "destinations", "visit_categories"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_28_100826) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_29_143701) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "conditions", force: :cascade do |t|
-    t.integer "type", default: 0, null: false
+    t.integer "condition_type", default: 0, null: false
     t.integer "value", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false

--- a/test/controllers/search_results_controller_test.rb
+++ b/test/controllers/search_results_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SearchResultsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/destinations.yml
+++ b/test/fixtures/destinations.yml
@@ -1,0 +1,21 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  visit_category_id: 1
+  name: MyString
+  address: MyString
+  latitude: 1.5
+  longitude: 1.5
+  rating: 1.5
+  image: MyString
+  business_hours: MyString
+
+two:
+  visit_category_id: 1
+  name: MyString
+  address: MyString
+  latitude: 1.5
+  longitude: 1.5
+  rating: 1.5
+  image: MyString
+  business_hours: MyString

--- a/test/fixtures/visit_categories.yml
+++ b/test/fixtures/visit_categories.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: 1
+
+two:
+  name: 1

--- a/test/models/destination_test.rb
+++ b/test/models/destination_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DestinationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/visit_category_test.rb
+++ b/test/models/visit_category_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class VisitCategoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
以下のテーブルを追加しました。

```
create_table "destinations", force: :cascade do |t|
    t.bigint "visit_category_id"
    t.string "name", null: false
    t.string "address", null: false
    t.float "latitude", null: false
    t.float "longitude", null: false
    t.float "rating"
    t.string "image"
    t.string "business_hours"
    t.datetime "created_at", null: false
    t.datetime "updated_at", null: false
    t.index ["visit_category_id"], name: "index_destinations_on_visit_category_id"
  end
  
    create_table "visit_categories", force: :cascade do |t|
    t.integer "name", null: false
    t.datetime "created_at", null: false
    t.datetime "updated_at", null: false
  end

```

Closes #33 
Closes #63 