### PR TITLE
後で行く機能の追加

### DIFF
--- a/app/controllers/destinations_controller.rb
+++ b/app/controllers/destinations_controller.rb
@@ -18,7 +18,11 @@ class DestinationsController < ApplicationController
   end
 
   def favorites
-    @favorite_destinations = current_user.destinations.includes(:favorite_destinations).order(created_at: :desc)
+    @favorite_destinations = current_user.favorites.includes(:favorite_destinations).order(created_at: :desc)
+  end
+
+  def future_visits
+    @future_visit_destinations = current_user.upcoming_destinations.includes(:future_visits).order(created_at: :desc)
   end
 
   private

--- a/app/controllers/future_visits_controller.rb
+++ b/app/controllers/future_visits_controller.rb
@@ -1,15 +1,15 @@
-class FavoriteDestinationsController < ApplicationController
+class FutureVisitsController < ApplicationController
   before_action :require_login, only: %i[create destroy]
 
   def create
     destination = Destination.find(params[:destination_id])
-    current_user.add_favorite(destination)
+    current_user.add_future_visit(destination)
     redirect_to destination_path(destination)
   end
 
   def destroy
-    destination = current_user.favorites.find_by(id: params[:destination_id])
-    current_user.unfavorite(destination)
+    destination = current_user.upcoming_destinations.find_by(id: params[:destination_id])
+    current_user.remove_future_visit(destination)
     redirect_to destination_path(destination)
   end
 end

--- a/app/models/future_visit.rb
+++ b/app/models/future_visit.rb
@@ -1,6 +1,6 @@
 class FutureVisit < ApplicationRecord
   belongs_to :user
-  belongs_to :desitination
+  belongs_to :destination
 
-  validates :user_id, uniqueness: { scope: :desitination_id }
+  validates :user_id, uniqueness: { scope: :destination_id }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,8 +2,8 @@ class User < ApplicationRecord
   has_many :conditions
   has_many :favorite_destinations, dependent: :destroy
   has_many :future_visits, dependent: :destroy
-  has_many :destinations, through: :favorite_destinations, source: :destination
-  has_many :future_visit_destinations, through: :future_visits, source: :destination
+  has_many :favorites, through: :favorite_destinations, source: :destination
+  has_many :upcoming_destinations, through: :future_visits, source: :destination
 
   validates :uid, presence: true
   validates :name, presence: true
@@ -18,15 +18,29 @@ class User < ApplicationRecord
     end
   end
 
-  def favorite(destination)
-    destinations << destination
+  #お気に入り機能
+  def add_favorite(destination)
+    favorites << destination
   end
   
   def unfavorite(destination)
-    destinations.destroy(destination)
+    favorites.destroy(destination)
   end
   
   def favorite?(destination)
-    destinations.include?(destination)
+    favorites.include?(destination)
+  end
+
+  #後で行く機能
+  def add_future_visit(destination)
+    upcoming_destinations << destination
+  end
+  
+  def remove_future_visit(destination)
+    upcoming_destinations.destroy(destination)
+  end
+  
+  def future_visit?(destination)
+    upcoming_destinations.include?(destination)
   end
 end

--- a/app/views/destinations/future_visits.html.erb
+++ b/app/views/destinations/future_visits.html.erb
@@ -1,0 +1,32 @@
+<div class="container pt-3">
+  <div class="row">
+    <div class="col-12">
+      <div class="row">
+        <div class="col-sm-12 col-lg-4 mb-3">
+          <h2 class="text-lg menu items-center">後で行く一覧</h2>
+            <div class="bg-base-200 menu items-center">
+              <% if @future_visit_destinations.present? %>
+                <% @future_visit_destinations.each do |destination| %>
+                  <div id="destination-id-<%= destination.id %>">
+                    <div class="card">
+                      <ul id="places">
+                        <li class="text-lg"><%= destination.name %></li>
+                        <% if destination.image.present? %>
+                          <li><img src="<%= get_photo_url(destination.image) %>" alt="<%= destination.name %>" width="400" height="300"></li>
+                        <% end %>
+                        <li><%= destination.address %></li>
+                        <li><%= destination.rating %></li>
+                        <li><%= link_to "詳細", destination_path(destination)%></li>
+                      </ul>
+                    </div>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+        <% else %>
+          <p>後で行くに登録されたスポットがありません</p>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/destinations/show.html.erb
+++ b/app/views/destinations/show.html.erb
@@ -15,6 +15,7 @@
           <li class="text-lg py-4"><%= @destination.name %> </li>
           <div class="favorite flex-none flex justify-end">
             <% if logged_in? %>
+            <%= render 'shared/future_visit_button', destination: @destination %>
               <%= render 'shared/favorite', destination: @destination %>
             <% end %>
           </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -48,7 +48,7 @@
           <details>
             <summary>メニュー</summary>
             <ul class="bg-base-100 rounded-t-none p-2">
-              <li><%= link_to "後で行きたい", "#", class: "btn btn-ghost" %></li>
+              <li><%= link_to "後で行きたい", future_visits_destinations_path , class: "btn btn-ghost" %></li>
               <li><%= link_to "お気に入り", favorites_destinations_path, class: "btn btn-ghost" %></li>
               <li><%= link_to "マイページ", users_path, class: "btn btn-ghost" %></li>
               <li><%= link_to "ログアウト", logout_path, data: { turbo_method: :delete }, class: "btn btn-ghost" %></li>

--- a/app/views/shared/_future_visit_button.html.erb
+++ b/app/views/shared/_future_visit_button.html.erb
@@ -1,0 +1,11 @@
+<div class='ms-auto'>
+    <% if current_user.future_visit?(destination) %>
+      <%= button_to future_visit_path(destination_id: destination.id), method: :delete, class: "btn btn-ghost btn-sm" do %>
+  <div class="swap-on"><%= image_tag "future_visit_icon.svg", size:'28x28' %></div>
+  <% end %>
+    <% else %>
+      <%= button_to future_visits_path(destination_id: destination.id), method: :post, class: "btn btn-ghost btn-sm" do %>
+  <div class="swap-off"><%= image_tag "not_future_visit_icon.svg", size:'28x28' %></div>
+  <% end %>
+    <% end %>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,7 +4,7 @@
     <%= image_tag @user.image, size: "200x200" %>
     <a>ユーザーネーム： <%= @user.name %></a>
     <li><%= link_to "お気に入り", favorites_destinations_path %></li>
-    <li><%= link_to "後で行きたい", favorites_destinations_path %></li>
+    <li><%= link_to "後で行きたい", future_visits_destinations_path %></li>
   </ul>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   resources :destinations, only: %i[create show] do
     collection do
       get :favorites
+      get :future_visits
     end
   end
   resources :favorite_destinations, only: %i[create destroy]


### PR DESCRIPTION
- 概要
- [ ] usersテーブルとdestinationsテーブルの中間テーブルとしてfuture_visitsテーブルの作成
```
  create_table "future_visits", force: :cascade do |t|
    t.bigint "user_id"
    t.bigint "destination_id"
    t.datetime "created_at", null: false
    t.datetime "updated_at", null: false
    t.index ["destination_id"], name: "index_future_visits_on_destination_id"
    t.index ["user_id", "destination_id"], name: "index_future_visits_on_user_id_and_destination_id", unique: true
    t.index ["user_id"], name: "index_future_visits_on_user_id"
  end
```
- [ ] コントローラーよビューページ(後で行く一覧表示)の作成
- [ ] お気に入り機能の関連付けの名前と被る箇所があったため、お気に入りのアソシエーション名をdestinations → favoritesに変更